### PR TITLE
Refactor listing form into modular steps

### DIFF
--- a/client/src/__mocks__/fileMock.ts
+++ b/client/src/__mocks__/fileMock.ts
@@ -1,0 +1,1 @@
+export default "test-file-stub";

--- a/client/src/__tests__/ListingSteps.test.tsx
+++ b/client/src/__tests__/ListingSteps.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CategoryStep } from "@/components/create-listing/CategoryStep";
+import { ListingTypeStep } from "@/components/create-listing/ListingTypeStep";
+import { VehicleDetailsStep } from "@/components/create-listing/VehicleDetailsStep";
+import { CATEGORIES } from "@/data/categories";
+
+describe("Listing step components", () => {
+  it("allows choosing a listing type", async () => {
+    const onSelect = jest.fn();
+    const user = userEvent.setup();
+    render(<ListingTypeStep value="" onSelect={onSelect} />);
+
+    await user.click(screen.getByRole("button", { name: /je vends/i }));
+
+    expect(onSelect).toHaveBeenCalledWith("sale");
+  });
+
+  it("renders categories and triggers selection", async () => {
+    const onSelect = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CategoryStep
+        categories={CATEGORIES}
+        listingType="sale"
+        selectedCategoryId=""
+        onSelect={onSelect}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /voitures - utilitaires/i }),
+    );
+
+    expect(onSelect).toHaveBeenCalledWith("voiture-utilitaire");
+  });
+
+  it("renders subcategories and calls onSelect", async () => {
+    const category = CATEGORIES[0];
+    const onSelect = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <VehicleDetailsStep
+        category={category}
+        selectedSubcategoryId=""
+        onSelect={onSelect}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /voiture/i }));
+
+    expect(onSelect).toHaveBeenCalledWith("voiture");
+  });
+});

--- a/client/src/__tests__/useListingNavigation.test.ts
+++ b/client/src/__tests__/useListingNavigation.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useListingNavigation } from "@/hooks/useListingNavigation";
+
+describe("useListingNavigation", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("auto advances from step 1 to 2 when listing type is selected", () => {
+    const initialProps = {
+      totalSteps: 12,
+      formState: {
+        listingType: "" as const,
+        category: "",
+        subcategory: "",
+        condition: undefined,
+      },
+      needsConditionStep: () => false,
+      isSearchForParts: () => false,
+      isServiceCategory: () => false,
+      isSearchListing: () => false,
+    };
+
+    const { result, rerender } = renderHook(
+      (props) => useListingNavigation(props),
+      { initialProps },
+    );
+
+    act(() => {
+      rerender({
+        ...initialProps,
+        formState: { ...initialProps.formState, listingType: "sale" },
+      });
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(result.current.currentStep).toBe(2);
+  });
+
+  it("moves to condition step when required", () => {
+    const props = {
+      totalSteps: 12,
+      formState: {
+        listingType: "sale" as const,
+        category: "voiture-utilitaire",
+        subcategory: "voiture",
+        condition: undefined,
+      },
+      needsConditionStep: () => true,
+      isSearchForParts: () => false,
+      isServiceCategory: () => false,
+      isSearchListing: () => false,
+    };
+
+    const { result } = renderHook(() => useListingNavigation(props));
+
+    act(() => {
+      result.current.setCurrentStep(3);
+      result.current.goToNextStep();
+    });
+
+    expect(result.current.currentStep).toBe(4);
+  });
+});

--- a/client/src/__tests__/useRegistrationNumber.test.ts
+++ b/client/src/__tests__/useRegistrationNumber.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from "@testing-library/react";
+
+import { useRegistrationNumber } from "@/hooks/useRegistrationNumber";
+
+describe("useRegistrationNumber", () => {
+  it("formats SIV registration numbers", () => {
+    const { result } = renderHook(() => useRegistrationNumber());
+
+    expect(result.current.formatRegistrationNumber("aa123aa")).toBe(
+      "AA-123-AA",
+    );
+  });
+
+  it("formats FNI registration numbers", () => {
+    const { result } = renderHook(() => useRegistrationNumber());
+
+    expect(result.current.formatRegistrationNumber("1234ab56")).toBe(
+      "1234 AB 56",
+    );
+  });
+
+  it("validates invalid input", () => {
+    const { result } = renderHook(() => useRegistrationNumber());
+
+    expect(result.current.validateRegistrationNumber("123")).toEqual({
+      isValid: false,
+      message:
+        "Format invalide. Utilisez le format SIV (AA-123-AA) ou FNI (1234 AB 56)",
+    });
+  });
+});

--- a/client/src/components/create-listing/CategoryStep.tsx
+++ b/client/src/components/create-listing/CategoryStep.tsx
@@ -1,0 +1,82 @@
+import { Check } from "lucide-react";
+
+import type { CategoryDefinition } from "@/data/categories";
+
+interface CategoryStepProps {
+  categories: CategoryDefinition[];
+  selectedCategoryId: string;
+  onSelect: (categoryId: string) => void;
+  listingType: "sale" | "search" | "";
+}
+
+export const CategoryStep: React.FC<CategoryStepProps> = ({
+  categories,
+  selectedCategoryId,
+  onSelect,
+  listingType,
+}) => {
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-8">
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          Choisissez une catégorie
+        </h2>
+        <p className="text-gray-600">
+          Sélectionnez la catégorie qui correspond le mieux à votre {listingType === "sale" ? "annonce" : "recherche"}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {categories.map((category) => {
+          const IconComponent = category.icon;
+          return (
+            <button
+              key={category.id}
+              onClick={() => onSelect(category.id)}
+              type="button"
+              className={`relative p-6 rounded-2xl border-2 transition-all duration-200 text-left ${
+                selectedCategoryId === category.id
+                  ? "border-primary-bolt-500 bg-primary-bolt-50"
+                  : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
+              }`}
+            >
+              <div className="flex items-start space-x-4">
+                <div className="p-3 flex items-center justify-center">
+                  {category.image ? (
+                    <img
+                      src={category.image}
+                      alt={category.name}
+                      className="h-12 w-12 object-contain"
+                    />
+                  ) : (
+                    <div
+                      className={`p-3 rounded-xl bg-gradient-to-r ${category.color} shadow-lg flex items-center justify-center`}
+                    >
+                      <IconComponent className="h-6 w-6 text-white" />
+                    </div>
+                  )}
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                    {category.name}
+                  </h3>
+                  <p className="text-sm text-gray-600">
+                    {category.subcategories.map((sub) => sub.name).join(", ")}
+                  </p>
+                </div>
+              </div>
+
+              {selectedCategoryId === category.id && (
+                <div className="absolute top-4 right-4">
+                  <div className="w-6 h-6 bg-primary-bolt-500 rounded-full flex items-center justify-center">
+                    <Check className="h-4 w-4 text-white" />
+                  </div>
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/create-listing/ListingTypeStep.tsx
+++ b/client/src/components/create-listing/ListingTypeStep.tsx
@@ -1,0 +1,68 @@
+import { Check } from "lucide-react";
+import { CTA_ICONS } from "@/data/categories";
+
+export type ListingTypeValue = "sale" | "search";
+
+interface ListingTypeStepProps {
+  value: ListingTypeValue | "";
+  onSelect: (value: ListingTypeValue) => void;
+}
+
+const OPTIONS: Array<{ id: ListingTypeValue; title: string; description: string; icon: string }> = [
+  {
+    id: "sale",
+    title: "Je vends",
+    description:
+      "Déposer une annonce pour vendre un véhicule, une pièce détachée ou proposer un service",
+    icon: CTA_ICONS.sell,
+  },
+  {
+    id: "search",
+    title: "Je cherche",
+    description:
+      "Publier une demande de recherche pour trouver un véhicule, une pièce ou un service spécifique",
+    icon: CTA_ICONS.search,
+  },
+];
+
+export const ListingTypeStep: React.FC<ListingTypeStepProps> = ({ value, onSelect }) => {
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-8">
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">Type d'annonce</h2>
+        <p className="text-gray-600">Que souhaitez-vous faire ?</p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-2xl mx-auto">
+        {OPTIONS.map((option) => (
+          <button
+            key={option.id}
+            onClick={() => onSelect(option.id)}
+            type="button"
+            className={`relative p-8 rounded-2xl border-2 transition-all duration-200 text-center ${
+              value === option.id
+                ? "border-primary-bolt-500 bg-primary-bolt-50"
+                : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
+            }`}
+          >
+            <div className="mb-4">
+              <div className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto">
+                <img src={option.icon} alt={option.title} className="w-18 h-18" />
+              </div>
+            </div>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">{option.title}</h3>
+            <p className="text-sm text-gray-600">{option.description}</p>
+
+            {value === option.id && (
+              <div className="absolute top-4 right-4">
+                <div className="w-6 h-6 bg-primary-bolt-500 rounded-full flex items-center justify-center">
+                  <Check className="h-4 w-4 text-white" />
+                </div>
+              </div>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/create-listing/VehicleDetailsStep.tsx
+++ b/client/src/components/create-listing/VehicleDetailsStep.tsx
@@ -1,0 +1,69 @@
+import { Check } from "lucide-react";
+
+import type { CategoryDefinition } from "@/data/categories";
+
+interface VehicleDetailsStepProps {
+  category: CategoryDefinition;
+  selectedSubcategoryId: string;
+  onSelect: (subcategoryId: string) => void;
+}
+
+export const VehicleDetailsStep: React.FC<VehicleDetailsStepProps> = ({
+  category,
+  selectedSubcategoryId,
+  onSelect,
+}) => {
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-8">
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          Choisissez une sous-famille
+        </h2>
+        <p className="text-gray-600">
+          Précisez le type de {category.name.toLowerCase()}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {category.subcategories.map((subcategory) => (
+          <button
+            key={subcategory.id}
+            onClick={() => onSelect(subcategory.id)}
+            type="button"
+            className={`relative p-4 rounded-xl border-2 transition-all duration-200 text-center ${
+              selectedSubcategoryId === subcategory.id
+                ? "border-primary-bolt-500 bg-primary-bolt-50"
+                : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
+            }`}
+          >
+            <div className="w-16 h-16 rounded-xl flex items-center justify-center mx-auto mb-3">
+              {subcategory.image ? (
+                <img
+                  src={subcategory.image}
+                  alt={subcategory.name}
+                  className="h-14 w-14 object-contain"
+                />
+              ) : (
+                <div
+                  className={`w-12 h-12 ${subcategory.bgColor ?? "bg-gray-100"} rounded-xl flex items-center justify-center`}
+                >
+                  <div className={`h-6 w-6 ${subcategory.color}`}>⚪</div>
+                </div>
+              )}
+            </div>
+
+            <h3 className="font-semibold text-gray-900">{subcategory.name}</h3>
+
+            {selectedSubcategoryId === subcategory.id && (
+              <div className="absolute top-2 right-2">
+                <div className="w-6 h-6 bg-primary-bolt-500 rounded-full flex items-center justify-center">
+                  <Check className="h-4 w-4 text-white" />
+                </div>
+              </div>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/client/src/data/categories.ts
+++ b/client/src/data/categories.ts
@@ -1,0 +1,208 @@
+import type { LucideIcon } from "lucide-react";
+import { Bike, Car, Package, Settings } from "lucide-react";
+
+import aerienIcon from "@/assets/aerien_1753810777764.png";
+import autreServiceIcon from "@/assets/autre_1752251142652.png";
+import bateauIcon from "@/assets/bateau_1752249742336.png";
+import caravaneIcon from "@/assets/caravane_1752249166091.png";
+import chercherIcon from "@/assets/chercher_1752258100621.png";
+import entretienIcon from "@/assets/entretien_1752251142651.png";
+import jetskiIcon from "@/assets/Jetski_1752249742334.png";
+import motosImage from "@/assets/motos-scooters_1752244968742.png";
+import motosIcon from "@/assets/motos-scooters_1752244968742.png";
+import piecesImage from "@/assets/pieces-detachees_1752244968743.png";
+import quadIcon from "@/assets/Quad_1752249742337.png";
+import remorquageIcon from "@/assets/remorquage_1752251142654.png";
+import remorqueIcon from "@/assets/remorque_1752249166090.png";
+import reparationIcon from "@/assets/reparation_1752251142655.png";
+import scooterIcon from "@/assets/scooter_1752088210843.png";
+import servicesImage from "@/assets/services-entretien_1752244968744.png";
+import utilitaireIcon from "@/assets/utilitaire_1752249166091.png";
+import vendreIcon from "@/assets/vendre_1752258100618.png";
+import voitureIcon from "@/assets/voiture-_1752249166092.png";
+import voitureImage from "@/assets/voiture-2_1752244968736.png";
+
+export interface SubcategoryDefinition {
+  id: string;
+  name: string;
+  image?: string;
+  color: string;
+  bgColor?: string;
+}
+
+export interface CategoryDefinition {
+  id: string;
+  name: string;
+  icon: LucideIcon;
+  image?: string;
+  color: string;
+  isMaterial: boolean;
+  subcategories: SubcategoryDefinition[];
+}
+
+export const CATEGORIES: CategoryDefinition[] = [
+  {
+    id: "voiture-utilitaire",
+    name: "Voitures - Utilitaires",
+    icon: Car,
+    image: voitureImage,
+    color: "from-blue-500 to-blue-600",
+    isMaterial: true,
+    subcategories: [
+      {
+        id: "voiture",
+        name: "Voiture",
+        image: voitureIcon,
+        color: "text-blue-500",
+        bgColor: "bg-blue-100",
+      },
+      {
+        id: "utilitaire",
+        name: "Utilitaire",
+        image: utilitaireIcon,
+        color: "text-blue-600",
+        bgColor: "bg-blue-100",
+      },
+      {
+        id: "remorque",
+        name: "Remorque",
+        image: remorqueIcon,
+        color: "text-indigo-500",
+        bgColor: "bg-indigo-100",
+      },
+      {
+        id: "caravane",
+        name: "Caravane / Camping-car",
+        image: caravaneIcon,
+        color: "text-purple-500",
+        bgColor: "bg-purple-100",
+      },
+    ],
+  },
+  {
+    id: "motos-quad-marine",
+    name: "Motos - Quad - Marine",
+    icon: Bike,
+    image: motosImage,
+    color: "from-emerald-500 to-emerald-600",
+    isMaterial: true,
+    subcategories: [
+      {
+        id: "moto",
+        name: "Moto",
+        image: motosIcon,
+        color: "text-emerald-500",
+        bgColor: "bg-emerald-100",
+      },
+      {
+        id: "scooter",
+        name: "Scooter",
+        image: scooterIcon,
+        color: "text-teal-500",
+        bgColor: "bg-teal-100",
+      },
+      {
+        id: "quad",
+        name: "Quad",
+        image: quadIcon,
+        color: "text-orange-500",
+        bgColor: "bg-orange-100",
+      },
+      {
+        id: "jetski",
+        name: "Jetski",
+        image: jetskiIcon,
+        color: "text-blue-500",
+        bgColor: "bg-blue-100",
+      },
+      {
+        id: "bateau",
+        name: "Bateau",
+        image: bateauIcon,
+        color: "text-sky-500",
+        bgColor: "bg-sky-100",
+      },
+      {
+        id: "aerien",
+        name: "Aérien",
+        image: aerienIcon,
+        color: "text-indigo-500",
+        bgColor: "bg-indigo-100",
+      },
+    ],
+  },
+  {
+    id: "services",
+    name: "Services & entretien",
+    icon: Settings,
+    image: servicesImage,
+    color: "from-amber-500 to-amber-600",
+    isMaterial: false,
+    subcategories: [
+      {
+        id: "reparation",
+        name: "Réparation & mécanique",
+        image: reparationIcon,
+        color: "text-amber-500",
+        bgColor: "bg-amber-100",
+      },
+      {
+        id: "remorquage",
+        name: "Remorquage & assistance",
+        image: remorquageIcon,
+        color: "text-red-500",
+        bgColor: "bg-red-100",
+      },
+      {
+        id: "entretien",
+        name: "Entretien & nettoyage",
+        image: entretienIcon,
+        color: "text-green-500",
+        bgColor: "bg-green-100",
+      },
+      {
+        id: "autre-service",
+        name: "Autres services",
+        image: autreServiceIcon,
+        color: "text-gray-500",
+        bgColor: "bg-gray-100",
+      },
+    ],
+  },
+  {
+    id: "pieces",
+    name: "Pièces détachées",
+    icon: Package,
+    image: piecesImage,
+    color: "from-purple-500 to-purple-600",
+    isMaterial: false,
+    subcategories: [
+      {
+        id: "piece-moto",
+        name: "Pièces moto",
+        image: motosImage,
+        color: "text-purple-500",
+        bgColor: "bg-purple-100",
+      },
+      {
+        id: "piece-voiture",
+        name: "Pièces voiture",
+        image: voitureImage,
+        color: "text-blue-500",
+        bgColor: "bg-blue-100",
+      },
+      {
+        id: "autre-piece",
+        name: "Autres pièces",
+        image: piecesImage,
+        color: "text-purple-500",
+        bgColor: "bg-purple-100",
+      },
+    ],
+  },
+];
+
+export const CTA_ICONS = {
+  sell: vendreIcon,
+  search: chercherIcon,
+};

--- a/client/src/data/contact.ts
+++ b/client/src/data/contact.ts
@@ -1,0 +1,75 @@
+export interface CountryCodeDefinition {
+  code: string;
+  name: string;
+  length: number;
+  format: (value: string) => string;
+}
+
+export const COUNTRY_CODES: CountryCodeDefinition[] = [
+  {
+    code: "+33",
+    name: "France",
+    length: 9,
+    format: (num: string) =>
+      num.replace(/(\d{1})(\d{2})(\d{2})(\d{2})(\d{2})/, "$1 $2 $3 $4 $5"),
+  },
+  {
+    code: "+1",
+    name: "États-Unis/Canada",
+    length: 10,
+    format: (num: string) =>
+      num.replace(/(\d{3})(\d{3})(\d{4})/, "($1) $2-$3"),
+  },
+  {
+    code: "+44",
+    name: "Royaume-Uni",
+    length: 10,
+    format: (num: string) => num.replace(/(\d{4})(\d{3})(\d{3})/, "$1 $2 $3"),
+  },
+  {
+    code: "+49",
+    name: "Allemagne",
+    length: 10,
+    format: (num: string) => num.replace(/(\d{3})(\d{3})(\d{4})/, "$1 $2 $3"),
+  },
+  {
+    code: "+34",
+    name: "Espagne",
+    length: 9,
+    format: (num: string) => num.replace(/(\d{3})(\d{3})(\d{3})/, "$1 $2 $3"),
+  },
+  {
+    code: "+39",
+    name: "Italie",
+    length: 10,
+    format: (num: string) => num.replace(/(\d{3})(\d{3})(\d{4})/, "$1 $2 $3"),
+  },
+  {
+    code: "+32",
+    name: "Belgique",
+    length: 9,
+    format: (num: string) =>
+      num.replace(/(\d{3})(\d{2})(\d{2})(\d{2})/, "$1 $2 $3 $4"),
+  },
+  {
+    code: "+41",
+    name: "Suisse",
+    length: 9,
+    format: (num: string) =>
+      num.replace(/(\d{2})(\d{3})(\d{2})(\d{2})/, "$1 $2 $3 $4"),
+  },
+  {
+    code: "+212",
+    name: "Maroc",
+    length: 9,
+    format: (num: string) =>
+      num.replace(/(\d{1})(\d{2})(\d{2})(\d{2})(\d{2})/, "$1 $2 $3 $4 $5"),
+  },
+  {
+    code: "+213",
+    name: "Algérie",
+    length: 9,
+    format: (num: string) =>
+      num.replace(/(\d{1})(\d{2})(\d{2})(\d{2})(\d{2})/, "$1 $2 $3 $4 $5"),
+  },
+];

--- a/client/src/data/vehicle.ts
+++ b/client/src/data/vehicle.ts
@@ -1,0 +1,313 @@
+export type VehicleEquipmentKey =
+  | "car"
+  | "motorcycle"
+  | "utility"
+  | "caravan"
+  | "trailer"
+  | "scooter"
+  | "quad"
+  | "jetski"
+  | "boat"
+  | "aircraft";
+
+export type VehicleTypeKey = VehicleEquipmentKey;
+
+export const VEHICLE_EQUIPMENT: Record<VehicleEquipmentKey, string[]> = {
+  car: [
+    "Toit ouvrant / Toit panoramique",
+    "Climatisation",
+    "GPS",
+    "Sièges chauffants",
+    "Caméra de recul",
+    "Radar de recul",
+    "Jantes alliage",
+    "Feux LED / Xénon",
+    "Vitres électriques",
+    "Airbags",
+    "Sièges électriques",
+    "Attelage",
+    "Régulateur de vitesse",
+    "Bluetooth",
+    "Système audio premium",
+    "Cuir",
+  ],
+  motorcycle: [
+    "ABS",
+    "Contrôle de traction",
+    "Modes de conduite",
+    "Éclairage LED",
+    "Quickshifter",
+    "Chauffage poignées",
+    "Pare-brise",
+    "Top case",
+    "Sacoches",
+    "Antivol",
+    "Compteur digital",
+    "USB",
+  ],
+  utility: [
+    "Climatisation",
+    "GPS",
+    "Caméra de recul",
+    "Radar de recul",
+    "Attelage",
+    "Cloison de séparation",
+    "Hayon arrière",
+    "Porte latérale",
+    "Plancher bois",
+    "Éclairage LED cargo",
+    "Prise 12V",
+    "Radio Bluetooth",
+  ],
+  caravan: [
+    "Chauffage",
+    "Eau courante",
+    "WC",
+    "Douche",
+    "Frigo",
+    "Plaques de cuisson",
+    "Four",
+    "TV",
+    "Auvent",
+    "Climatisation",
+    "Panneaux solaires",
+    "Antenne satellite",
+  ],
+  trailer: [
+    "Bâche de protection",
+    "Ridelles amovibles",
+    "Rampes de chargement",
+    "Sangles d'arrimage",
+    "Roue de secours",
+    "Éclairage LED",
+    "Plancher antidérapant",
+    "Support vélo",
+  ],
+  scooter: [
+    "ABS",
+    "Coffre sous selle",
+    "Éclairage LED",
+    "Prise USB",
+    "Pare-brise",
+    "Top case",
+    "Antivol",
+    "Compteur digital",
+  ],
+  quad: [
+    "Suspension sport",
+    "Freins à disque",
+    "Démarreur électrique",
+    "Pneus tout-terrain",
+    "Treuil",
+    "Protection",
+    "Éclairage LED",
+    "Attelage",
+  ],
+  jetski: [
+    "Système audio",
+    "GPS",
+    "Éclairage LED",
+    "Compartiments étanches",
+    "Échelle de remontée",
+    "Remorque incluse",
+    "Housse de protection",
+  ],
+  boat: [
+    "GPS",
+    "Sondeur",
+    "Radio VHF",
+    "Pilote automatique",
+    "Éclairage LED",
+    "Taud de soleil",
+    "Échelle de bain",
+    "Douche de pont",
+    "WC",
+    "Cuisine",
+    "Couchettes",
+  ],
+  aircraft: [
+    "Parachute de secours",
+    "GPS",
+    "Radio",
+    "Variomètre",
+    "Sac de portage",
+    "Kit d'entretien",
+    "Housse de protection",
+    "Manuel d'utilisation",
+  ],
+};
+
+export const VEHICLE_TYPES: Record<VehicleTypeKey, string[]> = {
+  car: [
+    "Citadine",
+    "Berline",
+    "SUV",
+    "Break",
+    "Coupé",
+    "Cabriolet",
+    "Monospace",
+    "Pickup",
+  ],
+  utility: [
+    "Camionnette",
+    "Fourgon",
+    "Plateau",
+    "Benne",
+    "Frigorifique",
+    "Hayon",
+    "Autre",
+  ],
+  caravan: [
+    "Caravane pliante",
+    "Caravane rigide",
+    "Camping-car",
+    "Cellule amovible",
+    "Autre",
+  ],
+  trailer: [
+    "Remorque bagagère",
+    "Remorque porte-voiture",
+    "Remorque plateau",
+    "Remorque benne",
+    "Remorque fermée",
+    "Autre",
+  ],
+  motorcycle: [
+    "Sportive",
+    "Routière",
+    "Trail",
+    "Custom",
+    "Roadster",
+    "Enduro",
+    "Cross",
+    "Autre",
+  ],
+  scooter: [
+    "Scooter 50cc",
+    "Scooter 125cc",
+    "Scooter 250cc",
+    "Maxi-scooter",
+    "Scooter électrique",
+    "Scooter vintage",
+    "Autre",
+  ],
+  quad: [
+    "Quad sport",
+    "Quad utilitaire",
+    "Quad enfant",
+    "Side-by-side",
+    "Autre",
+  ],
+  aircraft: [
+    "ULM pendulaire",
+    "ULM multiaxe",
+    "Parapente",
+    "Paramoteur",
+    "Planeur",
+    "Avion léger",
+    "Hélicoptère",
+    "Autre",
+  ],
+  boat: [
+    "Bateau à moteur",
+    "Voilier",
+    "Semi-rigide",
+    "Pneumatique",
+    "Catamaran",
+    "Pêche promenade",
+    "Runabout",
+    "Autre",
+  ],
+  jetski: ["Jet à bras", "Jet assis", "Jet 3 places", "Jet de course", "Autre"],
+};
+
+export const TRANSMISSION_TYPES = [
+  { value: "manual", label: "Manuelle" },
+  { value: "automatic", label: "Automatique" },
+  { value: "semi-automatic", label: "Semi-automatique" },
+];
+
+export const COLORS = [
+  "Blanc",
+  "Noir",
+  "Gris",
+  "Argent",
+  "Rouge",
+  "Bleu",
+  "Vert",
+  "Jaune",
+  "Orange",
+  "Violet",
+  "Marron",
+  "Beige",
+  "Autre",
+];
+
+export const DOORS = [2, 3, 4, 5] as const;
+
+export const UPHOLSTERY_TYPES = [
+  { value: "tissu", label: "Tissu" },
+  { value: "cuir_partiel", label: "Cuir partiel" },
+  { value: "cuir", label: "Cuir" },
+  { value: "velours", label: "Velours" },
+  { value: "alcantara", label: "Alcantara" },
+];
+
+export const EMISSION_CLASSES = [
+  { value: "euro1", label: "Euro 1" },
+  { value: "euro2", label: "Euro 2" },
+  { value: "euro3", label: "Euro 3" },
+  { value: "euro4", label: "Euro 4" },
+  { value: "euro5", label: "Euro 5" },
+  { value: "euro6", label: "Euro 6" },
+];
+
+export const LICENSE_TYPES = [
+  { value: "A", label: "Permis A" },
+  { value: "A1", label: "Permis A1" },
+  { value: "A2", label: "Permis A2" },
+  { value: "AL", label: "Permis AL" },
+  { value: "sans_permis", label: "Sans permis" },
+];
+
+export const SERVICE_TYPES = [
+  "Réparation mécanique",
+  "Réparation carrosserie",
+  "Entretien",
+  "Révision",
+  "Contrôle technique",
+  "Remorquage",
+  "Dépannage",
+  "Autre",
+];
+
+export const PART_CATEGORIES = [
+  "Moteur",
+  "Transmission",
+  "Freinage",
+  "Suspension",
+  "Électronique",
+  "Carrosserie",
+  "Intérieur",
+  "Éclairage",
+  "Pneumatiques",
+  "Autre",
+];
+
+export const PART_CONDITIONS = [
+  { value: "new", label: "Neuf" },
+  { value: "used", label: "Occasion" },
+];
+
+export const VEHICLE_CONDITIONS = [
+  {
+    value: "en_circulation",
+    label: "Roulant",
+    description: "Véhicule en état de circulation",
+  },
+  {
+    value: "accidente",
+    label: "Accidenté",
+    description: "Véhicule accidenté, vendu en l'état",
+  },
+];

--- a/client/src/hooks/useListingNavigation.ts
+++ b/client/src/hooks/useListingNavigation.ts
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { ListingTypeValue } from "@/components/create-listing/ListingTypeStep";
+
+export interface ListingNavigationState {
+  listingType: ListingTypeValue | "";
+  category: string;
+  subcategory: string;
+  condition?: string;
+}
+
+interface UseListingNavigationOptions {
+  totalSteps: number;
+  formState: ListingNavigationState;
+  needsConditionStep: () => boolean;
+  isSearchForParts: () => boolean;
+  isServiceCategory: () => boolean;
+  isSearchListing: () => boolean;
+}
+
+export const useListingNavigation = ({
+  totalSteps,
+  formState,
+  needsConditionStep,
+  isSearchForParts,
+  isServiceCategory,
+  isSearchListing,
+}: UseListingNavigationOptions) => {
+  const [currentStep, setCurrentStep] = useState(1);
+  const [autoAdvanceEnabled, setAutoAdvanceEnabled] = useState(true);
+
+  useEffect(() => {
+    if (!autoAdvanceEnabled) {
+      return;
+    }
+
+    if (currentStep === 1 && formState.listingType) {
+      const timeout = setTimeout(() => setCurrentStep(2), 300);
+      return () => clearTimeout(timeout);
+    }
+  }, [autoAdvanceEnabled, currentStep, formState.listingType]);
+
+  useEffect(() => {
+    if (!autoAdvanceEnabled) {
+      return;
+    }
+
+    if (currentStep === 2 && formState.category) {
+      const timeout = setTimeout(() => setCurrentStep(3), 300);
+      return () => clearTimeout(timeout);
+    }
+  }, [autoAdvanceEnabled, currentStep, formState.category]);
+
+  useEffect(() => {
+    if (!autoAdvanceEnabled) {
+      return;
+    }
+
+    if (currentStep === 3 && formState.subcategory) {
+      const nextStep = needsConditionStep() ? 4 : 5;
+      const timeout = setTimeout(() => setCurrentStep(nextStep), 300);
+      return () => clearTimeout(timeout);
+    }
+  }, [
+    autoAdvanceEnabled,
+    currentStep,
+    formState.subcategory,
+    needsConditionStep,
+  ]);
+
+  useEffect(() => {
+    if (!autoAdvanceEnabled) {
+      return;
+    }
+
+    if (currentStep === 4 && formState.condition && needsConditionStep()) {
+      const timeout = setTimeout(() => setCurrentStep(5), 300);
+      return () => clearTimeout(timeout);
+    }
+  }, [
+    autoAdvanceEnabled,
+    currentStep,
+    formState.condition,
+    needsConditionStep,
+  ]);
+
+  const goToNextStep = useCallback(() => {
+    let nextStepNumber = currentStep + 1;
+
+    if (currentStep === 2) {
+      nextStepNumber = 3;
+    } else if (currentStep === 3) {
+      nextStepNumber = needsConditionStep() ? 4 : 5;
+    } else if (currentStep === 4) {
+      nextStepNumber = 5;
+    } else {
+      if (isSearchForParts()) {
+        if (currentStep === 5) {
+          nextStepNumber = 7;
+        } else if (currentStep === 7) {
+          nextStepNumber = 8;
+        } else if (currentStep === 8) {
+          nextStepNumber = 11;
+        }
+      } else if (isServiceCategory()) {
+        if (currentStep === 5) {
+          nextStepNumber = 7;
+        }
+      } else if (isSearchListing()) {
+        if (currentStep === 8) {
+          nextStepNumber = 10;
+        }
+      }
+    }
+
+    if (nextStepNumber <= totalSteps) {
+      setCurrentStep(nextStepNumber);
+    }
+  }, [
+    currentStep,
+    totalSteps,
+    isSearchForParts,
+    isServiceCategory,
+    isSearchListing,
+    needsConditionStep,
+  ]);
+
+  const goToPreviousStep = useCallback(() => {
+    let previousStepNumber = currentStep - 1;
+
+    if (currentStep === 4 && !needsConditionStep()) {
+      previousStepNumber = 3;
+    } else if (currentStep === 5) {
+      previousStepNumber = needsConditionStep() ? 4 : 3;
+    } else {
+      if (isSearchForParts()) {
+        if (currentStep === 11) {
+          previousStepNumber = 8;
+        } else if (currentStep === 8) {
+          previousStepNumber = 7;
+        } else if (currentStep === 7) {
+          previousStepNumber = 5;
+        }
+      } else if (isServiceCategory()) {
+        if (currentStep === 7) {
+          previousStepNumber = 5;
+        }
+      } else if (isSearchListing()) {
+        if (currentStep === 10) {
+          previousStepNumber = 8;
+        }
+      }
+    }
+
+    if (previousStepNumber >= 1) {
+      setCurrentStep(previousStepNumber);
+    }
+  }, [
+    currentStep,
+    isSearchForParts,
+    isServiceCategory,
+    isSearchListing,
+    needsConditionStep,
+  ]);
+
+  const enableAutoAdvance = useCallback(() => setAutoAdvanceEnabled(true), []);
+  const disableAutoAdvance = useCallback(() => setAutoAdvanceEnabled(false), []);
+
+  return {
+    autoAdvanceEnabled,
+    currentStep,
+    disableAutoAdvance,
+    enableAutoAdvance,
+    goToNextStep,
+    goToPreviousStep,
+    setCurrentStep,
+  } as const;
+};

--- a/client/src/hooks/useRegistrationNumber.ts
+++ b/client/src/hooks/useRegistrationNumber.ts
@@ -1,0 +1,65 @@
+export interface RegistrationValidationResult {
+  isValid: boolean;
+  message: string;
+}
+
+export const useRegistrationNumber = () => {
+  const validateRegistrationNumber = (
+    regNumber: string,
+  ): RegistrationValidationResult => {
+    if (!regNumber) return { isValid: true, message: "" };
+
+    const cleaned = regNumber.replace(/[\s-]/g, "").toUpperCase();
+
+    const sivPattern = /^[A-Z]{2}[0-9]{3}[A-Z]{2}$/;
+    const fniPattern = /^[0-9]{1,4}[A-Z]{1,3}[0-9]{1,3}$/;
+
+    if (sivPattern.test(cleaned)) {
+      return { isValid: true, message: "Format SIV valide (AA-123-AA)" };
+    }
+
+    if (fniPattern.test(cleaned)) {
+      return { isValid: true, message: "Format FNI valide (1234 AB 56)" };
+    }
+
+    return {
+      isValid: false,
+      message:
+        "Format invalide. Utilisez le format SIV (AA-123-AA) ou FNI (1234 AB 56)",
+    };
+  };
+
+  const formatRegistrationNumber = (value: string): string => {
+    if (!value) return "";
+
+    const cleaned = value.replace(/[\s-]/g, "").toUpperCase();
+
+    if (cleaned.length >= 5) {
+      const sivPattern = /^([A-Z]{2})([0-9]{3})([A-Z]{0,2}).*$/;
+      const match = cleaned.match(sivPattern);
+      if (match) {
+        const [, letters1, numbers, letters2] = match;
+        if (letters2.length === 2) {
+          return `${letters1}-${numbers}-${letters2}`;
+        }
+        if (letters2.length === 1) {
+          return `${letters1}-${numbers}-${letters2}`;
+        }
+        return `${letters1}-${numbers}`;
+      }
+    }
+
+    if (cleaned.length >= 6) {
+      const fniPattern = /^([0-9]{1,4})([A-Z]{1,3})([0-9]{1,3}).*$/;
+      const match = cleaned.match(fniPattern);
+      if (match) {
+        const [, numbers1, letters, numbers2] = match;
+        return `${numbers1} ${letters} ${numbers2}`;
+      }
+    }
+
+    return cleaned;
+  };
+
+  return { formatRegistrationNumber, validateRegistrationNumber } as const;
+};

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/client/src/$1",
+    "\\.(css|less|scss|sass)$": "identity-obj-proxy",
+    "\\.(png|jpg|jpeg|gif|svg)$": "<rootDir>/client/src/__mocks__/fileMock.ts",
+  },
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  globals: {
+    "ts-jest": {
+      tsconfig: "tsconfig.json",
+      useESM: true,
+    },
+  },
+  transform: {
+    "^.+\\.[tj]sx?$": ["ts-jest", { useESM: true }],
+  },
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -118,7 +119,15 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.2.5"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- extract listing metadata into dedicated data modules for categories, vehicle attributes, and contact formatting
- break the create listing flow into reusable step components and navigation/registration hooks
- add Jest configuration, mocks, and targeted tests to cover the new hooks and step components

## Testing
- npm test -- --runInBand *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d84e6352ac832f9edad2785c46a307